### PR TITLE
Fixing the ShortDateFormat call

### DIFF
--- a/ReaderDemo/Main.dfm
+++ b/ReaderDemo/Main.dfm
@@ -1,9 +1,9 @@
 object FrmMain: TFrmMain
   Left = 236
   Top = 156
-  Width = 783
-  Height = 540
   Caption = 'TAR File "Explorer"'
+  ClientHeight = 481
+  ClientWidth = 767
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
@@ -13,36 +13,37 @@ object FrmMain: TFrmMain
   Menu = MnuMain
   OldCreateOrder = False
   Position = poScreenCenter
+  OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13
   object ToolBar: TToolBar
     Left = 0
     Top = 0
-    Width = 775
+    Width = 767
     Height = 49
     BorderWidth = 2
     ButtonHeight = 36
-    ButtonWidth = 74
+    ButtonWidth = 68
     Caption = 'ToolBar'
     Images = IglToolBar
     ShowCaptions = True
     TabOrder = 0
     object ToolButton1: TToolButton
       Left = 0
-      Top = 2
+      Top = 0
       Action = ActFileOpen
     end
     object ToolButton2: TToolButton
-      Left = 74
-      Top = 2
+      Left = 68
+      Top = 0
       Action = ActExtract
     end
   end
   object LvwFiles: TListView
     Left = 0
     Top = 49
-    Width = 775
-    Height = 418
+    Width = 767
+    Height = 413
     Align = alClient
     Columns = <
       item
@@ -80,8 +81,8 @@ object FrmMain: TFrmMain
   end
   object StatusBar: TStatusBar
     Left = 0
-    Top = 467
-    Width = 775
+    Top = 462
+    Width = 767
     Height = 19
     Panels = <
       item

--- a/ReaderDemo/Main.pas
+++ b/ReaderDemo/Main.pas
@@ -16,9 +16,11 @@ unit Main;
 interface
 
 uses
+
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   Menus, ImgList, ComCtrls, ToolWin, ActnList,
-  LibTar;
+  LibTar, Actions, ImageList;
+
 
 type
   TFrmMain = class(TForm)
@@ -43,7 +45,9 @@ type
     procedure ActExitExecute(Sender: TObject);
     procedure ActFileOpenExecute(Sender: TObject);
     procedure ActExtractExecute(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
+    FShortDateFormatStr:String;
   public
   end;
 
@@ -86,7 +90,7 @@ begin
         Item := LvwFiles.Items.Add;
         Item.Caption := string (DirRec.Name);
         Item.SubItems.Add (IntToStr (DirRec.Size));
-        Item.SubItems.Add (FormatDateTime (ShortDateFormat + ' HH:NN:SS', DirRec.DateTime));
+        Item.SubItems.Add (FormatDateTime (FShortDateFormatStr + ' HH:NN:SS', DirRec.DateTime));
         Item.SubItems.Add (PermissionString (DirRec.Permissions) + ' ' + FILETYPE_NAME [DirRec.FileType]);
         Item.SubItems.Add (IntToStr (DirRec.UID)+'-'+string (DirRec.UserName) + ' / ' +
                            IntToStr (DirRec.GID)+'-'+string (DirRec.GroupName));
@@ -106,6 +110,32 @@ begin
     END;
   StatusBar.Panels[0].Text := IntToStr (LvwFiles.Items.Count) + ' Files';
   StatusBar.Panels[1].Text := IntToStr (Bytes) + ' Bytes';
+end;
+
+procedure TFrmMain.FormCreate(Sender: TObject);
+begin
+
+  // http://docwiki.embarcadero.com/RADStudio/Rio/en/Compiler_Versions
+
+  // < VER150
+  {$IF CompilerVersion < 15.0}
+     FShortDateFormatStr := ShortDateFormat;
+  {$ENDIF}
+
+  //VER150  - VER210
+  // On older versions (D7+) use:
+  {$IF (CompilerVersion >= 15.0) AND (CompilerVersion <= 21.0)}
+     GetLocaleFormatSettings(GetThreadLocale, FormatSettings);
+     FShortDateFormatStr := Formatsettings.ShortDateFormat;
+  {$ENDIF}
+
+  //VER220 - VER330
+  //And in newer versions (XE+):
+  {$IF CompilerVersion > 21.0 }
+     FormatSettings := TFormatSettings.Create(GetThreadLocale);
+     FShortDateFormatStr := Formatsettings.ShortDateFormat;
+  {$ENDIF}
+
 end;
 
 procedure TFrmMain.ActExtractExecute(Sender: TObject);


### PR DESCRIPTION
This fix will allow the Reader Demo to work with Delphi 10 Tokyo as well as fix it for correct use in back version given the history of Embarcaderros changes to that command in the past.